### PR TITLE
Enforce nesting depth limit in loader to prevent O(n²) parsing

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+
+- package-ecosystem: cargo
+  directory: /
+  schedule:
+    interval: weekly

--- a/src/de.rs
+++ b/src/de.rs
@@ -109,7 +109,7 @@ impl<'de> Deserializer<'de> {
                     pos: &mut pos,
                     jumpcount: &mut jumpcount,
                     path: Path::Root,
-                    remaining_depth: 128,
+                    remaining_depth: crate::RECURSION_DEPTH_LIMIT as u8,
                     current_enum: None,
                 })?;
                 if let Some(parse_error) = document.error {
@@ -129,7 +129,7 @@ impl<'de> Deserializer<'de> {
             pos: &mut pos,
             jumpcount: &mut jumpcount,
             path: Path::Root,
-            remaining_depth: 128,
+            remaining_depth: crate::RECURSION_DEPTH_LIMIT as u8,
             current_enum: None,
         })?;
         if let Some(parse_error) = document.error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,6 +184,8 @@ mod ser;
 pub mod value;
 pub mod with;
 
+const RECURSION_DEPTH_LIMIT: usize = 128;
+
 // Prevent downstream code from implementing the Index trait.
 mod private {
     pub trait Sealed {}

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -55,6 +55,8 @@ impl<'input> Loader<'input> {
             aliases: BTreeMap::new(),
         };
 
+        let mut depth = 0;
+
         loop {
             let (event, mark) = match parser.next() {
                 Ok((event, mark)) => (event, mark),
@@ -94,6 +96,12 @@ impl<'input> Loader<'input> {
                     Event::Scalar(scalar)
                 }
                 YamlEvent::SequenceStart(mut sequence_start) => {
+                    depth += 1;
+                    if depth > crate::RECURSION_DEPTH_LIMIT {
+                        document.error =
+                            Some(error::new(ErrorImpl::RecursionLimitExceeded(mark)).shared());
+                        return Some(document);
+                    }
                     if let Some(anchor) = sequence_start.anchor.take() {
                         let id = anchors.len();
                         anchors.insert(anchor, id);
@@ -101,8 +109,17 @@ impl<'input> Loader<'input> {
                     }
                     Event::SequenceStart(sequence_start)
                 }
-                YamlEvent::SequenceEnd => Event::SequenceEnd,
+                YamlEvent::SequenceEnd => {
+                    depth = depth.saturating_sub(1);
+                    Event::SequenceEnd
+                }
                 YamlEvent::MappingStart(mut mapping_start) => {
+                    depth += 1;
+                    if depth > crate::RECURSION_DEPTH_LIMIT {
+                        document.error =
+                            Some(error::new(ErrorImpl::RecursionLimitExceeded(mark)).shared());
+                        return Some(document);
+                    }
                     if let Some(anchor) = mapping_start.anchor.take() {
                         let id = anchors.len();
                         anchors.insert(anchor, id);
@@ -110,7 +127,10 @@ impl<'input> Loader<'input> {
                     }
                     Event::MappingStart(mapping_start)
                 }
-                YamlEvent::MappingEnd => Event::MappingEnd,
+                YamlEvent::MappingEnd => {
+                    depth = depth.saturating_sub(1);
+                    Event::MappingEnd
+                }
             };
             document.events.push((event, mark));
         }

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -416,6 +416,37 @@ fn test_finite_recursion_arrays() {
 
 #[cfg(not(miri))]
 #[test]
+fn test_deeply_nested_flow_collection() {
+    // Regression test for https://github.com/yaml/yaml-serde/issues/1
+    // Deeply nested flow collections used to cause O(n²) parsing time.
+    // With the loader depth limit, this returns an error quickly.
+    let n = 10_000;
+    let yaml = r#"{"":["#.repeat(n) + &"]}".repeat(n);
+    let begin = std::time::Instant::now();
+    let result = yaml_serde::from_str::<serde::de::IgnoredAny>(&yaml);
+    let elapsed = begin.elapsed();
+    assert!(result.is_err(), "expected recursion limit error");
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("recursion limit exceeded"),
+        "unexpected error: {err}",
+    );
+    // Should complete nearly instantly, not in seconds.
+    assert!(
+        elapsed.as_millis() < 1000,
+        "took too long: {elapsed:?}",
+    );
+}
+
+#[cfg(not(miri))]
+#[test]
+fn test_nesting_at_depth_limit() {
+    let yaml = "[".repeat(128) + &"]".repeat(128);
+    yaml_serde::from_str::<serde::de::IgnoredAny>(&yaml).unwrap();
+}
+
+#[cfg(not(miri))]
+#[test]
 fn test_billion_laughs() {
     #[derive(Debug)]
     struct X;


### PR DESCRIPTION
- **Add const RECURSION_DEPTH_LIMIT**
- **Enforce nesting depth limit in loader to prevent O(n²) parsing**

Fixes #1
