### PR TITLE
Fix infinite loop when iterating documents past a parse error

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -59,6 +59,10 @@ impl<'input> Loader<'input> {
             let (event, mark) = match parser.next() {
                 Ok((event, mark)) => (event, mark),
                 Err(err) => {
+                    // The parser latches into an error state, so any further
+                    // call would yield the same error forever. Drop it so the
+                    // next `next_document` returns None and iteration ends.
+                    self.parser = None;
                     document.error = Some(Error::from(err).shared());
                     return Some(document);
                 }

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -159,6 +159,25 @@ fn test_second_document_syntax_error() {
 }
 
 #[test]
+fn test_syntax_error_terminates_iteration() {
+    // Malformed input must not loop forever when iterating documents.
+    // Regression test: the libyaml parser latches into an error state, so the
+    // loader has to stop after yielding the error document once.
+    let yaml = "app: {apikey";
+
+    let mut documents = 0;
+    let mut last_error = None;
+    for document in Deserializer::from_str(yaml) {
+        documents += 1;
+        last_error = Value::deserialize(document).err();
+        assert!(documents <= 1, "iteration did not terminate on bad input");
+    }
+
+    assert_eq!(documents, 1);
+    assert!(last_error.is_some());
+}
+
+#[test]
 fn test_missing_enum_tag() {
     #[derive(Deserialize, Debug)]
     pub enum E {


### PR DESCRIPTION
Iterating a `Deserializer` over malformed YAML never terminates. For example:

```rust
for (i, doc) in yaml_serde::Deserializer::from_str("app: {apikey").enumerate() {
    // never ends
}
```

Once libyaml hits a syntax error it stays in an error state and returns that same error on every subsequent call. The loader kept the parser around regardless, so each `next_document()` handed back a fresh error document and the iterator never finished.

This one line change drops the parser when it reports an error, so the next call returns `None` and iteration stops after yielding the error document once...matching how the `StreamEnd` branch already behaves.

Added a regression test in `tests/test_error.rs`.

This is the same problem as the long-standing dtolnay/serde-yaml#193, which can't be fixed upstream since that repo is archived.